### PR TITLE
Fix for an infinite loop when an application is installed into the perl installation.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Changes
 =======
 
+    - Fix to allow applications installed into the perl installation to 
+      use the inherited_path_to call.
+
 0.00008 - Jul 21 2010
     - Grrr, fix what was supposed to be fixed in 0.00006 for real 
 

--- a/lib/CatalystX/AppBuilder.pm
+++ b/lib/CatalystX/AppBuilder.pm
@@ -171,6 +171,7 @@ sub inherited_path_to {
                $f = $f->subdir(@paths)->stringify;
                last;
            }
+           last if $f->stringify eq $f->parent->stringify;
            $f = $f->parent;
         }
         $f;


### PR DESCRIPTION
We found that our app hung when we installed it and then tried to run it, rather than unpacking it to a directory and running it manually.  The appears to simply be because the inherited_path_to call assumes it will find a Makefile.PL somewhere and won't abort until it does.  I've just added a check to ensure if you get back to the root directory it should bail.
