### PR TITLE
Fixed bug causing the Makefile detection to crash.

### DIFF
--- a/lib/CatalystX/AppBuilder.pm
+++ b/lib/CatalystX/AppBuilder.pm
@@ -166,11 +166,11 @@ sub inherited_path_to {
         $m =~ s/::/\//g;
         $m .= '.pm';
         my $f = Path::Class::File->new($INC{$m})->parent;
-        while ($f) {
+        DESCENT: while ($f) {
             for my $stopper (qw(Makefile.PL Build.PL dist.ini minil.toml)) {
                 if (-f $f->file($stopper)) {
                     $f = $f->subdir(@paths)->stringify;
-                    last;
+                    last DESCENT;
                 }
             }
             last if $f->stringify eq $f->parent->stringify;


### PR DESCRIPTION
Error:  Can't call method "stringify" without a package or object
reference at ...CatalystX/AppBuilder.pm line 176.

This was because the last was operating on the new loop rather than the
original while loop it used to affect.